### PR TITLE
Fixed issue with Opensearch getting Strings for cited_by and relative…

### DIFF
--- a/config/es_indices_ins.yml
+++ b/config/es_indices_ins.yml
@@ -278,8 +278,8 @@ Indices:
         pb.title AS title,
         pb.authors AS authors,
         (CASE pb.publication_date WHEN '' THEN NULL ELSE pb.publication_date END) AS publication_date,
-        pb.cited_by AS cited_by,
-        pb.relative_citation_ratio AS relative_citation_ratio,
+        toInteger(pb.cited_by) AS cited_by,
+        toFloat(pb.relative_citation_ratio) AS relative_citation_ratio,
         COLLECT(DISTINCT({
           focus_area: apoc.text.split(pg.focus_area, ';'),
           program_id: pg.program_id,


### PR DESCRIPTION
…_citation_ratio instead of integers and floats